### PR TITLE
Raysep updates

### DIFF
--- a/irs/ipm.cuh
+++ b/irs/ipm.cuh
@@ -782,8 +782,8 @@ private:
 		set_threads(threads, 16, 16);
 		set_blocks(threads, blocks, num_ray_threads.re, num_ray_threads.im);
 
-		int* percentage = nullptr;
-		cudaMallocManaged(&percentage, sizeof(int));
+		unsigned long long int* percentage = nullptr;
+		cudaMallocManaged(&percentage, sizeof(unsigned long long int));
 		if (cuda_error("cudaMallocManaged(*percentage)", false, __FILE__, __LINE__)) return false;
 
 		*percentage = 1;

--- a/irs/ipm.cuh
+++ b/irs/ipm.cuh
@@ -41,15 +41,15 @@ public:
 	T m_solar = static_cast<T>(1);
 	T m_lower = static_cast<T>(0.01);
 	T m_upper = static_cast<T>(50);
-	T light_loss = static_cast<T>(0.001);
-	int rectangular = 1;
-	int approx = 0;
-	T safety_scale = static_cast<T>(1.37);
+	T light_loss = static_cast<T>(0.001); //average fraction of light lost due to scatter by the microlenses in the large deflection angle limit
+	int rectangular = 1; //whether star field is rectangular or circular
+	int approx = 0; //whether terms for alpha_smooth are exact or approximate
+	T safety_scale = static_cast<T>(1.37); //multiplicative factor over the shooting region to distribute the microlenses within
 	std::string starfile = "";
 	Complex<T> center_y = Complex<T>();
 	Complex<T> half_length_y = Complex<T>(5, 5);
 	Complex<int> num_pixels_y = Complex<int>(1000, 1000);
-	int num_rays_y = 1;
+	int num_rays_y = 1; //number density of rays per pixel in the source plane
 	int random_seed = 0;
 	int write_maps = 1;
 	int write_parities = 0;
@@ -102,11 +102,11 @@ private:
 	T mean_mass2_actual;
 
 	T mu_ave;
-	T num_rays_x;
-	T ray_sep;
+	T num_rays_x; //number density of rays per unit area in the image plane
+	Complex<T> ray_half_sep; //distance from center of cell to corner
 	Complex<T> center_x;
-	Complex<int> num_ray_blocks;
 	Complex<T> half_length_x;
+	Complex<int> num_ray_threads; //number of threads in x1 and x2 directions 
 	Complex<T> corner;
 	int taylor_smooth;
 
@@ -115,11 +115,9 @@ private:
 	int expansion_order;
 
 	T root_half_length;
-	int rays_level; //ray_sep * 2 ^ rays_level = root_half_length
 	int tree_levels = 0;
 	std::vector<TreeNode<T>*> tree = {};
 	std::vector<int> num_nodes = {};
-	int ray_blocks_level = 0;
 
 	/******************************************************************************
 	dynamic memory
@@ -385,9 +383,13 @@ private:
 			verbose);
 
 		/******************************************************************************
-		average separation between rays in one dimension is 1/sqrt(number density)
+		average area covered by one ray is 1 / number density
+		account for potential rectangular pixels and use half_length
 		******************************************************************************/
-		set_param("ray_sep", ray_sep, 1 / std::sqrt(num_rays_x), verbose);
+		ray_half_sep = Complex<T>(std::sqrt(half_length_y.re / half_length_y.im * num_pixels_y.im / num_pixels_y.re),
+							 std::sqrt(half_length_y.im / half_length_y.re * num_pixels_y.re / num_pixels_y.im));
+		ray_half_sep /= (2 * std::sqrt(num_rays_x));
+		set_param("ray_half_sep", ray_half_sep, ray_half_sep, verbose);
 
 		/******************************************************************************
 		shooting region is greater than outer boundary for macro-mapping by the size of
@@ -396,7 +398,13 @@ private:
 		******************************************************************************/
 		half_length_x = half_length_y + theta_star * std::sqrt(kappa_star * mean_mass2 / (mean_mass * light_loss)) * Complex<T>(1, 1);
 		half_length_x = Complex<T>(half_length_x.re / std::abs(1 - kappa_tot + shear), half_length_x.im / std::abs(1 - kappa_tot - shear));
+		/******************************************************************************
+		make shooting region a multiple of the ray separation
+		******************************************************************************/
+		num_ray_threads = Complex<int>(half_length_x.re / (2 * ray_half_sep.re), half_length_x.im / (2 * ray_half_sep.im)) + Complex<int>(1, 1);
+		half_length_x = Complex<T>(2 * ray_half_sep.re * num_ray_threads.re, 2 * ray_half_sep.im * num_ray_threads.im);
 		set_param("half_length_x", half_length_x, half_length_x, verbose);
+		set_param("num_ray_threads", num_ray_threads, 2 * num_ray_threads, verbose);
 
 		center_x = Complex<T>(center_y.re / (1 - kappa_tot + shear), center_y.im / (1 - kappa_tot - shear));
 		set_param("center_x", center_x, center_x, verbose);
@@ -615,11 +623,7 @@ private:
 		{
 			root_half_length = corner.abs();
 		}
-		/******************************************************************************
-		upscale root half length so it is a power of 2 multiple of the ray separation
-		******************************************************************************/
-		set_param("rays_level", rays_level, static_cast<int>(std::log2(root_half_length) - std::log2(ray_sep)) + 1, verbose);
-		set_param("root_half_length", root_half_length, ray_sep * (1 << rays_level), verbose);
+		root_half_length *= 1.1; //slight buffer for containing all the stars
 
 		/******************************************************************************
 		push empty pointer into tree, add 1 to number of nodes, and allocate memory
@@ -703,45 +707,6 @@ private:
 		t_elapsed = stopwatch.stop();
 		std::cout << "Done creating children and sorting stars. Elapsed time: " << t_elapsed << " seconds.\n\n";
 
-
-		/******************************************************************************
-		make shooting region a multiple of the lowest level node length, or a multiple
-		of a factor of two smaller version of the root length that doesn't exceed the
-		size of the corner
-		******************************************************************************/
-		ray_blocks_level = tree_levels;
-		num_ray_blocks = Complex<int>(half_length_x / (2 * root_half_length) * (1 << ray_blocks_level)) + Complex<int>(1, 1);
-		Complex<T> tmp_half_length_x = Complex<T>(2 * root_half_length / (1 << ray_blocks_level)) * num_ray_blocks;
-		while ((tmp_half_length_x.re > corner.re || tmp_half_length_x.im > corner.im) &&
-			ray_blocks_level <= rays_level)
-		{
-			ray_blocks_level++;
-			num_ray_blocks = Complex<int>(half_length_x / (2 * root_half_length) * (1 << ray_blocks_level)) + Complex<int>(1, 1);
-			tmp_half_length_x = Complex<T>(2 * root_half_length / (1 << ray_blocks_level)) * num_ray_blocks;
-		}
-
-		/******************************************************************************
-		if number of ray blocks needed is less than the number of blocks available on
-		the device, increase the ray blocks level to better take advantage of
-		parallelization
-		******************************************************************************/
-		while ((2 * num_ray_blocks.re * 2 * num_ray_blocks.im < cuda_device_prop.multiProcessorCount) &&
-			ray_blocks_level <= rays_level)
-		{
-			ray_blocks_level++;
-			num_ray_blocks = Complex<int>(half_length_x / (2 * root_half_length) * (1 << ray_blocks_level)) + Complex<int>(1, 1);
-			tmp_half_length_x = Complex<T>(2 * root_half_length / (1 << ray_blocks_level)) * num_ray_blocks;
-		}
-
-		set_param("ray_blocks_level", ray_blocks_level, ray_blocks_level, verbose);
-		if (ray_blocks_level > rays_level)
-		{
-			std::cerr << "Error. ray_blocks_level > rays_level\n";
-			return false;
-		}
-		set_param("half_length_x", half_length_x, tmp_half_length_x, verbose);
-		set_param("num_ray_blocks", num_ray_blocks, 2 * num_ray_blocks, verbose);
-
 		/******************************************************************************
 		END create root node, then create children and sort stars
 		******************************************************************************/
@@ -815,7 +780,7 @@ private:
 	bool shoot_cells(bool verbose)
 	{
 		set_threads(threads, 16, 16);
-		set_blocks(threads, blocks, 16 * num_ray_blocks.re, 16 * num_ray_blocks.im);
+		set_blocks(threads, blocks, num_ray_threads.re, num_ray_threads.im);
 
 		int* percentage = nullptr;
 		cudaMallocManaged(&percentage, sizeof(int));
@@ -828,8 +793,8 @@ private:
 		******************************************************************************/
 		std::cout << "Shooting cells...\n";
 		stopwatch.start();
-		shoot_cells_kernel<T> <<<blocks, threads, sizeof(TreeNode<T>) + treenode::MAX_NUM_STARS_DIRECT * sizeof(star<T>)>>> (kappa_tot, shear, theta_star, stars, kappa_star, tree[0], rays_level - ray_blocks_level,
-			rectangular, corner, approx, taylor_smooth, center_x, half_length_x, num_ray_blocks,
+		shoot_cells_kernel<T> <<<blocks, threads>>> (kappa_tot, shear, theta_star, stars, kappa_star, tree[0],
+			rectangular, corner, approx, taylor_smooth, ray_half_sep, num_ray_threads, center_x, half_length_x,
 			center_y, half_length_y, pixels_minima, pixels_saddles, pixels, num_pixels_y, percentage);
 		if (cuda_error("shoot_rays_kernel", true, __FILE__, __LINE__)) return false;
 		t_shoot_cells = stopwatch.stop();
@@ -1028,14 +993,13 @@ private:
 		outfile << "half_length_x2 " << half_length_x.im << "\n";
 		outfile << "num_rays_y " << num_rays_y << "\n";
 		outfile << "num_rays_x " << num_rays_x << "\n";
-		outfile << "ray_sep " << ray_sep << "\n";
+		outfile << "ray_half_sep_1 " << ray_half_sep.re << "\n";
+		outfile << "ray_half_sep_2 " << ray_half_sep.im << "\n";
 		outfile << "alpha_error " << alpha_error << "\n";
 		outfile << "expansion_order " << expansion_order << "\n";
 		outfile << "root_half_length " << root_half_length << "\n";
-		outfile << "rays_level " << rays_level << "\n";
-		outfile << "ray_blocks_level " << ray_blocks_level << "\n";
-		outfile << "num_ray_blocks_1 " << num_ray_blocks.re << "\n";
-		outfile << "num_ray_blocks_2 " << num_ray_blocks.im << "\n";
+		outfile << "num_ray_threads_1 " << num_ray_threads.re << "\n";
+		outfile << "num_ray_threads_2 " << num_ray_threads.im << "\n";
 		outfile << "tree_levels " << tree_levels << "\n";
 		outfile << "t_shoot_cells " << t_shoot_cells << "\n";
 		outfile.close();

--- a/irs/ipm_functions.cuh
+++ b/irs/ipm_functions.cuh
@@ -111,7 +111,7 @@ template <typename T>
 __global__ void shoot_cells_kernel(T kappa, T gamma, T theta, star<T>* stars, T kappastar, TreeNode<T>* root,
 	int rectangular, Complex<T> corner, int approx, int taylor_smooth,
 	Complex<T> ray_half_sep, Complex<int> num_ray_threads, Complex<T> center_x, Complex<T> hlx,
-	Complex<T> center_y, Complex<T> hly, T* pixmin, T* pixsad, T* pixels, Complex<int> npixels, int* percentage)
+	Complex<T> center_y, Complex<T> hly, T* pixmin, T* pixsad, T* pixels, Complex<int> npixels, unsigned long long int* percentage)
 {
 	for (int j = blockIdx.y * blockDim.y + threadIdx.y; j < num_ray_threads.im; j += blockDim.y * gridDim.y)
 	{
@@ -139,11 +139,13 @@ __global__ void shoot_cells_kernel(T kappa, T gamma, T theta, star<T>* stars, T 
 				{
 					if (threadIdx.x == 0 && threadIdx.y == 0)
 					{
-						int p = atomicAdd(percentage, 1);
-						if (p * 100 / (num_ray_threads.re / blockDim.x * num_ray_threads.im / blockDim.y) 
-							> (p - 1) * 100 / (num_ray_threads.re / blockDim.x * num_ray_threads.im / blockDim.y))
+						unsigned long long int p = atomicAdd(percentage, 1);
+						unsigned long long int imax = num_ray_threads.re;
+						imax *= num_ray_threads.im;
+						imax /= (blockDim.x * blockDim.y);
+						if (p * 100 / imax > (p - 1) * 100 / imax)
 						{
-							device_print_progress(p, num_ray_threads.re / blockDim.x * num_ray_threads.im / blockDim.y);
+							device_print_progress(p, imax);
 						}
 					}
 					break;
@@ -213,11 +215,13 @@ __global__ void shoot_cells_kernel(T kappa, T gamma, T theta, star<T>* stars, T 
 			
 			if (threadIdx.x == 0 && threadIdx.y == 0)
 			{
-				int p = atomicAdd(percentage, 1);
-				if (p * 100 / (num_ray_threads.re / blockDim.x * num_ray_threads.im / blockDim.y) 
-					> (p - 1) * 100 / (num_ray_threads.re / blockDim.x * num_ray_threads.im / blockDim.y))
+				unsigned long long int p = atomicAdd(percentage, 1);
+				unsigned long long int imax = num_ray_threads.re;
+				imax *= num_ray_threads.im;
+				imax /= (blockDim.x * blockDim.y);
+				if (p * 100 / imax > (p - 1) * 100 / imax)
 				{
-					device_print_progress(p, num_ray_threads.re / blockDim.x * num_ray_threads.im / blockDim.y);
+					device_print_progress(p, imax);
 				}
 			}
 		}

--- a/irs/ipm_functions.cuh
+++ b/irs/ipm_functions.cuh
@@ -90,17 +90,16 @@ shoot rays from image plane to source plane
 \param stars -- pointer to array of point mass lenses
 \param kappastar -- convergence in point mass lenses
 \param root -- pointer to root node
-\param num_rays_factor -- log2(number of rays per unit half length)
 \param rectangular -- whether the star field is rectangular or not
 \param corner -- complex number denoting the corner of the rectangular field of
 				 point mass lenses
 \param approx -- whether the smooth matter deflection is approximate or not
 \param taylor_smooth -- degree of the taylor series for alpha_smooth if
 						approximate
+\param ray_half_sep -- half separation between central rays of shooting squares
+\param num_ray_threads -- number of threads of rays for the image plane shooting region
 \param center_x -- center of the image plane shooting region
 \param hlx -- half length of the image plane shooting region
-\param numrayblocks -- number of ray blocks for the image plane shooting region
-\param raysep -- separation between central rays of shooting squares
 \param center_y -- center of the source plane receiving region
 \param hly -- half length of the source plane receiving region
 \param pixmin -- pointer to array of positive parity pixels
@@ -109,159 +108,116 @@ shoot rays from image plane to source plane
 \param npixels -- number of pixels for one side of the receiving square
 ******************************************************************************/
 template <typename T>
-__global__ void shoot_cells_kernel(T kappa, T gamma, T theta, star<T>* stars, T kappastar, TreeNode<T>* root, int num_rays_factor,
+__global__ void shoot_cells_kernel(T kappa, T gamma, T theta, star<T>* stars, T kappastar, TreeNode<T>* root,
 	int rectangular, Complex<T> corner, int approx, int taylor_smooth,
-	Complex<T> center_x, Complex<T> hlx, Complex<int> numrayblocks,
+	Complex<T> ray_half_sep, Complex<int> num_ray_threads, Complex<T> center_x, Complex<T> hlx,
 	Complex<T> center_y, Complex<T> hly, T* pixmin, T* pixsad, T* pixels, Complex<int> npixels, int* percentage)
 {
-	Complex<T> block_half_length = Complex<T>(hlx.re / numrayblocks.re, hlx.im / numrayblocks.im);
-
-	extern __shared__ int shared_memory[];
-	TreeNode<T>* node = reinterpret_cast<TreeNode<T>*>(&shared_memory[0]);
-	star<T>* tmp_stars = reinterpret_cast<star<T>*>(&node[1]);
-	__shared__ int nstars;
-
-	for (int l = blockIdx.y; l < numrayblocks.im; l += gridDim.y)
+	for (int j = blockIdx.y * blockDim.y + threadIdx.y; j < num_ray_threads.im; j += blockDim.y * gridDim.y)
 	{
-		for (int k = blockIdx.x; k < numrayblocks.re; k += gridDim.x)
+		for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < num_ray_threads.re; i += blockDim.x * gridDim.x)
 		{
-			Complex<T> block_center = center_x - hlx + block_half_length + 2 * Complex<T>(block_half_length.re * k, block_half_length.im * l);
-			if (threadIdx.x == 0 && threadIdx.y == 0)
-			{
-				*node = *(treenode::get_nearest_node(block_center, root));
-				nstars = 0;
-			}
-			__syncthreads();
-			if (threadIdx.x == 0)
-			{
-				for (int j = threadIdx.y; j < node->numstars; j += blockDim.y)
-				{
-					tmp_stars[atomicAdd(&nstars, 1)] = stars[node->stars + j];
-				}
-			}
-			for (int i = threadIdx.x; i < node->num_neighbors; i += blockDim.x)
-			{
-				TreeNode<T>* neighbor = node->neighbors[i];
-				for (int j = threadIdx.y; j < neighbor->numstars; j += blockDim.y)
-				{
-					tmp_stars[atomicAdd(&nstars, 1)] = stars[neighbor->stars + j];
-				}
-			}
-			__syncthreads();
+			Complex<T> x[4];
 
-			if (threadIdx.x == 0 && threadIdx.y == 0)
-			{
-				node->num_neighbors = 0;
-				node->stars = 0;
-				node->numstars = nstars;
-			}
-			__syncthreads();
+			Complex<T> z = -hlx + ray_half_sep + 2 * Complex<T>(ray_half_sep.re * i, ray_half_sep.im * j);
 
-			int num_rays = (2 << num_rays_factor);
-			Complex<T> ray_half_sep = block_half_length / num_rays;
-			Complex<int> ypix;
-			Complex<T> z;
-			Complex<T> w;
-			for (int j = threadIdx.y; j < num_rays; j += blockDim.y)
-			{
-				for (int i = threadIdx.x; i < num_rays; i += blockDim.x)
-				{
-					Complex<T> x[4];
+			x[0] = z + ray_half_sep;
+			x[1] = z - ray_half_sep.conj();
+			x[2] = z - ray_half_sep;
+			x[3] = z + ray_half_sep.conj();
 
-					Complex<T> z = block_center - block_half_length + ray_half_sep + 2 * Complex<T>(ray_half_sep.re * i, ray_half_sep.im * j);
-
-					x[0] = z + ray_half_sep;
-					x[1] = z - ray_half_sep.conj();
-					x[2] = z - ray_half_sep;
-					x[3] = z + ray_half_sep.conj();
-
-					Complex<T> y[4];
+			Complex<T> y[4];
 #pragma unroll
-					for (int a = 0; a < 4; a++)
+			for (int a = 0; a < 4; a++)
+			{
+				TreeNode<T>* node = treenode::get_nearest_node(x[a], root);
+				y[a] = complex_image_to_source(x[a], kappa, gamma, theta, stars, kappastar, node, rectangular, corner, approx, taylor_smooth);
+				/******************************************************************************
+				if the ray location is the same as a star position, we will have a nan returned
+				******************************************************************************/
+				if (isnan(y[a].re) || isnan(y[a].im))
+				{
+					if (threadIdx.x == 0 && threadIdx.y == 0)
 					{
-						y[a] = complex_image_to_source(x[a], kappa, gamma, theta, tmp_stars, kappastar, node, rectangular, corner, approx, taylor_smooth);
-						/******************************************************************************
-						if the ray location is the same as a star position, we will have a nan returned
-						******************************************************************************/
-						if (isnan(y[a].re) || isnan(y[a].im))
+						int p = atomicAdd(percentage, 1);
+						if (p * 100 / (num_ray_threads.re / blockDim.x * num_ray_threads.im / blockDim.y) 
+							> (p - 1) * 100 / (num_ray_threads.re / blockDim.x * num_ray_threads.im / blockDim.y))
 						{
-							break;
-							continue;
-						}
-						/******************************************************************************
-						shift ray position relative to center
-						******************************************************************************/
-						y[a] -= center_y;
-					}
-
-#pragma unroll
-					for (int a = 0; a < 4; a++)
-					{
-						y[a] = point_to_pixel<T, T>(y[a], hly, npixels);
-						/******************************************************************************
-						reverse y coordinate so array forms image in correct orientation
-						******************************************************************************/
-						y[a].im = npixels.im - y[a].im;
-					}
-
-					Polygon<T> y_poly;
-
-					T image_plane_area = 2 * ray_half_sep.re * ray_half_sep.im * npixels.re * npixels.im / (2 * hly.re * 2 * hly.im);
-
-					y_poly.points[0] = y[0];
-					y_poly.points[1] = y[1];
-					y_poly.points[2] = y[2];
-					y_poly.numsides = 3;
-					if (fabs(y_poly.area()) < 1000 * image_plane_area)
-					{
-						if (pixmin && pixsad)
-						{
-							if (y_poly.area() < 0)
-							{
-								y_poly.allocate_area_among_pixels(image_plane_area, pixmin, npixels);
-							}
-							else
-							{
-								y_poly.allocate_area_among_pixels(image_plane_area, pixsad, npixels);
-							}
-						}
-						else
-						{
-							y_poly.allocate_area_among_pixels(image_plane_area, pixels, npixels);
+							device_print_progress(p, num_ray_threads.re / blockDim.x * num_ray_threads.im / blockDim.y);
 						}
 					}
+					break;
+					continue;
+				}
+				/******************************************************************************
+				shift ray position relative to center
+				******************************************************************************/
+				y[a] -= center_y;
+				
+				y[a] = point_to_pixel<T, T>(y[a], hly, npixels);
+				/******************************************************************************
+				reverse y coordinate so array forms image in correct orientation
+				******************************************************************************/
+				y[a].im = npixels.im - y[a].im;
+			}
 
-					y_poly.points[0] = y[2];
-					y_poly.points[1] = y[3];
-					y_poly.points[2] = y[0];
-					y_poly.numsides = 3;
-					if (fabs(y_poly.area()) < 1000 * image_plane_area)
+			Polygon<T> y_poly;
+
+			T image_plane_area = 2 * ray_half_sep.re * ray_half_sep.im * npixels.re * npixels.im / (2 * hly.re * 2 * hly.im);
+
+			y_poly.points[0] = y[0];
+			y_poly.points[1] = y[1];
+			y_poly.points[2] = y[2];
+			y_poly.numsides = 3;
+			if (fabs(y_poly.area()) < 1000 * image_plane_area)
+			{
+				if (pixmin && pixsad)
+				{
+					if (y_poly.area() < 0)
 					{
-						if (pixmin && pixsad)
-						{
-							if (y_poly.area() < 0)
-							{
-								y_poly.allocate_area_among_pixels(image_plane_area, pixmin, npixels);
-							}
-							else
-							{
-								y_poly.allocate_area_among_pixels(image_plane_area, pixsad, npixels);
-							}
-						}
-						else
-						{
-							y_poly.allocate_area_among_pixels(image_plane_area, pixels, npixels);
-						}
+						y_poly.allocate_area_among_pixels(image_plane_area, pixmin, npixels);
+					}
+					else
+					{
+						y_poly.allocate_area_among_pixels(image_plane_area, pixsad, npixels);
 					}
 				}
+				else
+				{
+					y_poly.allocate_area_among_pixels(image_plane_area, pixels, npixels);
+				}
 			}
-			__syncthreads();
+
+			y_poly.points[0] = y[2];
+			y_poly.points[1] = y[3];
+			y_poly.points[2] = y[0];
+			y_poly.numsides = 3;
+			if (fabs(y_poly.area()) < 1000 * image_plane_area)
+			{
+				if (pixmin && pixsad)
+				{
+					if (y_poly.area() < 0)
+					{
+						y_poly.allocate_area_among_pixels(image_plane_area, pixmin, npixels);
+					}
+					else
+					{
+						y_poly.allocate_area_among_pixels(image_plane_area, pixsad, npixels);
+					}
+				}
+				else
+				{
+					y_poly.allocate_area_among_pixels(image_plane_area, pixels, npixels);
+				}
+			}
+			
 			if (threadIdx.x == 0 && threadIdx.y == 0)
 			{
 				int p = atomicAdd(percentage, 1);
-				if (p * 100 / (numrayblocks.re * numrayblocks.im) > (p - 1) * 100 / (numrayblocks.re * numrayblocks.im))
+				if (p * 100 / (num_ray_threads.re / blockDim.x * num_ray_threads.im / blockDim.y) 
+					> (p - 1) * 100 / (num_ray_threads.re / blockDim.x * num_ray_threads.im / blockDim.y))
 				{
-					device_print_progress(p, numrayblocks.re * numrayblocks.im);
+					device_print_progress(p, num_ray_threads.re / blockDim.x * num_ray_threads.im / blockDim.y);
 				}
 			}
 		}

--- a/irs/irs.cuh
+++ b/irs/irs.cuh
@@ -786,8 +786,8 @@ private:
 		set_threads(threads, 16, 16);
 		set_blocks(threads, blocks, num_ray_threads.re, num_ray_threads.im);
 
-		int* percentage = nullptr;
-		cudaMallocManaged(&percentage, sizeof(int));
+		unsigned long long int* percentage = nullptr;
+		cudaMallocManaged(&percentage, sizeof(unsigned long long int));
 		if (cuda_error("cudaMallocManaged(*percentage)", false, __FILE__, __LINE__)) return false;
 
 		*percentage = 1;

--- a/irs/irs.cuh
+++ b/irs/irs.cuh
@@ -42,15 +42,15 @@ public:
 	T m_solar = static_cast<T>(1);
 	T m_lower = static_cast<T>(0.01);
 	T m_upper = static_cast<T>(50);
-	T light_loss = static_cast<T>(0.01);
-	int rectangular = 1;
-	int approx = 0;
-	T safety_scale = static_cast<T>(1.37);
+	T light_loss = static_cast<T>(0.01); //average fraction of light lost due to scatter by the microlenses in the large deflection angle limit
+	int rectangular = 1; //whether star field is rectangular or circular
+	int approx = 0; //whether terms for alpha_smooth are exact or approximate
+	T safety_scale = static_cast<T>(1.37); //multiplicative factor over the shooting region to distribute the microlenses within
 	std::string starfile = "";
 	Complex<T> center_y = Complex<T>();
 	Complex<T> half_length_y = Complex<T>(5, 5);
 	Complex<int> num_pixels_y = Complex<int>(1000, 1000);
-	int num_rays_y = 1000;
+	int num_rays_y = 100; //number density of rays per pixel in the source plane
 	int random_seed = 0;
 	int write_maps = 1;
 	int write_parities = 0;
@@ -103,11 +103,11 @@ private:
 	T mean_mass2_actual;
 
 	T mu_ave;
-	T num_rays_x;
-	T ray_sep;
+	T num_rays_x; //number density of rays per unit area in the image plane
+	Complex<T> ray_half_sep; //distance between rays, center to corner
 	Complex<T> center_x;
-	Complex<int> num_ray_blocks;
 	Complex<T> half_length_x;
+	Complex<int> num_ray_threads; //number of threads in x1 and x2 directions 
 	Complex<T> corner;
 	int taylor_smooth;
 
@@ -116,11 +116,9 @@ private:
 	int expansion_order;
 
 	T root_half_length;
-	int rays_level; //ray_sep * 2 ^ rays_level = root_half_length
 	int tree_levels = 0;
 	std::vector<TreeNode<T>*> tree = {};
 	std::vector<int> num_nodes = {};
-	int ray_blocks_level = 0;
 
 	unsigned long int num_rays_shot = 0;
 	unsigned long int num_rays_received = 0;
@@ -389,9 +387,13 @@ private:
 			verbose);
 		
 		/******************************************************************************
-		average separation between rays in one dimension is 1/sqrt(number density)
+		average area covered by one ray is 1 / number density
+		account for potential rectangular pixels and use half_length
 		******************************************************************************/
-		set_param("ray_sep", ray_sep, 1 / std::sqrt(num_rays_x), verbose);
+		ray_half_sep = Complex<T>(std::sqrt(half_length_y.re / half_length_y.im * num_pixels_y.im / num_pixels_y.re),
+							 std::sqrt(half_length_y.im / half_length_y.re * num_pixels_y.re / num_pixels_y.im));
+		ray_half_sep /= (2 * std::sqrt(num_rays_x));
+		set_param("ray_half_sep", ray_half_sep, ray_half_sep, verbose);
 
 		/******************************************************************************
 		shooting region is greater than outer boundary for macro-mapping by the size of
@@ -400,7 +402,13 @@ private:
 		******************************************************************************/
 		half_length_x = half_length_y + theta_star * std::sqrt(kappa_star * mean_mass2 / (mean_mass * light_loss)) * Complex<T>(1, 1);
 		half_length_x = Complex<T>(half_length_x.re / std::abs(1 - kappa_tot + shear), half_length_x.im / std::abs(1 - kappa_tot - shear));
+		/******************************************************************************
+		make shooting region a multiple of the ray separation
+		******************************************************************************/
+		num_ray_threads = Complex<int>(half_length_x.re / (2 * ray_half_sep.re), half_length_x.im / (2 * ray_half_sep.im)) + Complex<int>(1, 1);
+		half_length_x = Complex<T>(2 * ray_half_sep.re * num_ray_threads.re, 2 * ray_half_sep.im * num_ray_threads.im);
 		set_param("half_length_x", half_length_x, half_length_x, verbose);
+		set_param("num_ray_threads", num_ray_threads, 2 * num_ray_threads, verbose);
 
 		center_x = Complex<T>(center_y.re / (1 - kappa_tot + shear), center_y.im / (1 - kappa_tot - shear));
 		set_param("center_x", center_x, center_x, verbose);
@@ -619,11 +627,7 @@ private:
 		{
 			root_half_length = corner.abs();
 		}
-		/******************************************************************************
-		upscale root half length so it is a power of 2 multiple of the ray separation
-		******************************************************************************/
-		set_param("rays_level", rays_level, static_cast<int>(std::log2(root_half_length) - std::log2(ray_sep)) + 1, verbose);
-		set_param("root_half_length", root_half_length, ray_sep * (1 << rays_level), verbose);
+		root_half_length *= 1.1; //slight buffer for containing all the stars
 
 		/******************************************************************************
 		push empty pointer into tree, add 1 to number of nodes, and allocate memory
@@ -707,45 +711,6 @@ private:
 		t_elapsed = stopwatch.stop();
 		std::cout << "Done creating children and sorting stars. Elapsed time: " << t_elapsed << " seconds.\n\n";
 
-
-		/******************************************************************************
-		make shooting region a multiple of the lowest level node length, or a multiple
-		of a factor of two smaller version of the root length that doesn't exceed the
-		size of the corner
-		******************************************************************************/
-		ray_blocks_level = tree_levels;
-		num_ray_blocks = Complex<int>(half_length_x / (2 * root_half_length) * (1 << ray_blocks_level)) + Complex<int>(1, 1);
-		Complex<T> tmp_half_length_x = Complex<T>(2 * root_half_length / (1 << ray_blocks_level)) * num_ray_blocks;
-		while ((tmp_half_length_x.re > corner.re || tmp_half_length_x.im > corner.im) &&
-				ray_blocks_level <= rays_level)
-		{
-			ray_blocks_level++;
-			num_ray_blocks = Complex<int>(half_length_x / (2 * root_half_length) * (1 << ray_blocks_level)) + Complex<int>(1, 1);
-			tmp_half_length_x = Complex<T>(2 * root_half_length / (1 << ray_blocks_level)) * num_ray_blocks;
-		}
-
-		/******************************************************************************
-		if number of ray blocks needed is less than the number of blocks available on
-		the device, increase the ray blocks level to better take advantage of
-		parallelization
-		******************************************************************************/
-		while ((2 * num_ray_blocks.re * 2 * num_ray_blocks.im < cuda_device_prop.multiProcessorCount) &&
-			ray_blocks_level <= rays_level)
-		{
-			ray_blocks_level++;
-			num_ray_blocks = Complex<int>(half_length_x / (2 * root_half_length) * (1 << ray_blocks_level)) + Complex<int>(1, 1);
-			tmp_half_length_x = Complex<T>(2 * root_half_length / (1 << ray_blocks_level)) * num_ray_blocks;
-		}
-
-		set_param("ray_blocks_level", ray_blocks_level, ray_blocks_level, verbose);
-		if (ray_blocks_level > rays_level)
-		{
-			std::cerr << "Error. ray_blocks_level > rays_level\n";
-			return false;
-		}
-		set_param("half_length_x", half_length_x, tmp_half_length_x, verbose);
-		set_param("num_ray_blocks", num_ray_blocks, 2 * num_ray_blocks, verbose);
-
 		/******************************************************************************
 		END create root node, then create children and sort stars
 		******************************************************************************/
@@ -819,7 +784,7 @@ private:
 	bool shoot_rays(bool verbose)
 	{
 		set_threads(threads, 16, 16);
-		set_blocks(threads, blocks, 16 * num_ray_blocks.re, 16 * num_ray_blocks.im);
+		set_blocks(threads, blocks, num_ray_threads.re, num_ray_threads.im);
 
 		int* percentage = nullptr;
 		cudaMallocManaged(&percentage, sizeof(int));
@@ -832,15 +797,15 @@ private:
 		******************************************************************************/
 		std::cout << "Shooting rays...\n";
 		stopwatch.start();
-		shoot_rays_kernel<T> <<<blocks, threads, sizeof(TreeNode<T>) + treenode::MAX_NUM_STARS_DIRECT * sizeof(star<T>)>>> (kappa_tot, shear, theta_star, stars, kappa_star, tree[0], rays_level - ray_blocks_level,
-			rectangular, corner, approx, taylor_smooth, center_x, half_length_x, num_ray_blocks,
+		shoot_rays_kernel<T> <<<blocks, threads>>> (kappa_tot, shear, theta_star, stars, kappa_star, tree[0],
+			rectangular, corner, approx, taylor_smooth, ray_half_sep, num_ray_threads, center_x, half_length_x,
 			center_y, half_length_y, pixels_minima, pixels_saddles, pixels, num_pixels_y, percentage);
 		if (cuda_error("shoot_rays_kernel", true, __FILE__, __LINE__)) return false;
 		t_shoot_rays = stopwatch.stop();
 		std::cout << "\nDone shooting rays. Elapsed time: " << t_shoot_rays << " seconds.\n\n";
 
-		num_rays_shot = num_ray_blocks.re * num_ray_blocks.im;
-		num_rays_shot <<= 2 * (rays_level - ray_blocks_level + 1);
+		num_rays_shot = num_ray_threads.re;
+		num_rays_shot *= num_ray_threads.im;
 		set_param("num_rays_shot", num_rays_shot, num_rays_shot, verbose);
 
 		num_rays_received = thrust::reduce(thrust::device, pixels, pixels + num_pixels_y.re * num_pixels_y.im, num_rays_received);
@@ -1023,14 +988,13 @@ private:
 		outfile << "num_rays_y " << num_rays_y << "\n";
 		outfile << "mean_num_rays_y " << (1.0 * num_rays_received / (num_pixels_y.re * num_pixels_y.im)) << "\n";
 		outfile << "num_rays_x " << num_rays_x << "\n";
-		outfile << "ray_sep " << ray_sep << "\n";
+		outfile << "ray_half_sep_1 " << ray_half_sep.re << "\n";
+		outfile << "ray_half_sep_2 " << ray_half_sep.im << "\n";
 		outfile << "alpha_error " << alpha_error << "\n";
 		outfile << "expansion_order " << expansion_order << "\n";
 		outfile << "root_half_length " << root_half_length << "\n";
-		outfile << "rays_level " << rays_level << "\n";
-		outfile << "ray_blocks_level " << ray_blocks_level << "\n";
-		outfile << "num_ray_blocks_1 " << num_ray_blocks.re << "\n";
-		outfile << "num_ray_blocks_2 " << num_ray_blocks.im << "\n";
+		outfile << "num_ray_threads_1 " << num_ray_threads.re << "\n";
+		outfile << "num_ray_threads_2 " << num_ray_threads.im << "\n";
 		outfile << "tree_levels " << tree_levels << "\n";
 		outfile << "t_shoot_rays " << t_shoot_rays << "\n";
 		outfile << "num_rays_shot " << num_rays_shot << "\n";

--- a/irs/irs_functions.cuh
+++ b/irs/irs_functions.cuh
@@ -89,17 +89,16 @@ shoot rays from image plane to source plane
 \param stars -- pointer to array of point mass lenses
 \param kappastar -- convergence in point mass lenses
 \param root -- pointer to root node
-\param num_rays_factor -- log2(number of rays per unit half length)
 \param rectangular -- whether the star field is rectangular or not
 \param corner -- complex number denoting the corner of the rectangular field of
 				 point mass lenses
 \param approx -- whether the smooth matter deflection is approximate or not
 \param taylor_smooth -- degree of the taylor series for alpha_smooth if 
                         approximate
+\param ray_half_sep -- half separation between central rays of shooting squares
+\param num_ray_threads -- number of threads of rays for the image plane shooting region
 \param center_x -- center of the image plane shooting region
 \param hlx -- half length of the image plane shooting region
-\param numrayblocks -- number of ray blocks for the image plane shooting region
-\param raysep -- separation between central rays of shooting squares
 \param center_y -- center of the source plane receiving region
 \param hly -- half length of the source plane receiving region
 \param pixmin -- pointer to array of positive parity pixels
@@ -108,129 +107,98 @@ shoot rays from image plane to source plane
 \param npixels -- number of pixels for one side of the receiving square
 ******************************************************************************/
 template <typename T>
-__global__ void shoot_rays_kernel(T kappa, T gamma, T theta, star<T>* stars, T kappastar, TreeNode<T>* root, int num_rays_factor, 
+__global__ void shoot_rays_kernel(T kappa, T gamma, T theta, star<T>* stars, T kappastar, TreeNode<T>* root, 
 	int rectangular, Complex<T> corner, int approx, int taylor_smooth,
-	Complex<T> center_x, Complex<T> hlx, Complex<int> numrayblocks, 
+	Complex<T> ray_half_sep, Complex<int> num_ray_threads, Complex<T> center_x, Complex<T> hlx, 
 	Complex<T> center_y, Complex<T> hly, int* pixmin, int* pixsad, int* pixels, Complex<int> npixels, int* percentage)
 {
-	Complex<T> block_half_length = Complex<T>(hlx.re / numrayblocks.re, hlx.im / numrayblocks.im);
-	
-	extern __shared__ int shared_memory[];
-	TreeNode<T>* node = reinterpret_cast<TreeNode<T>*>(&shared_memory[0]);
-	star<T>* tmp_stars = reinterpret_cast<star<T>*>(&node[1]);
-	__shared__ int nstars;
-
-	for (int l = blockIdx.y; l < numrayblocks.im; l += gridDim.y)
+	for (int j = blockIdx.y * blockDim.y + threadIdx.y; j < num_ray_threads.im; j += blockDim.y * gridDim.y)
 	{
-		for (int k = blockIdx.x; k < numrayblocks.re; k += gridDim.x)
+		for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < num_ray_threads.re; i += blockDim.x * gridDim.x)
 		{
-			Complex<T> block_center = center_x - hlx + block_half_length + 2 * Complex<T>(block_half_length.re * k, block_half_length.im * l);
-			if (threadIdx.x == 0 && threadIdx.y == 0)
+			Complex<T> z = -hlx + ray_half_sep + 2 * Complex<T>(ray_half_sep.re * i, ray_half_sep.im * j);
+			TreeNode<T>* node = treenode::get_nearest_node(z, root);
+			Complex<T> w = complex_image_to_source<T>(z, kappa, gamma, theta, stars, kappastar, node, rectangular, corner, approx, taylor_smooth);
+			
+			/******************************************************************************
+			if the ray location is the same as a star position, we will have a nan returned
+			******************************************************************************/
+			if (isnan(w.re) || isnan(w.im))
 			{
-				*node = *(treenode::get_nearest_node(block_center, root));
-				nstars = 0;
-			}
-			__syncthreads();
-			if (threadIdx.x == 0)
-			{
-				for (int j = threadIdx.y; j < node->numstars; j += blockDim.y)
+				if (threadIdx.x == 0 && threadIdx.y == 0)
 				{
-					tmp_stars[atomicAdd(&nstars, 1)] = stars[node->stars + j];
+					int p = atomicAdd(percentage, 1) / 1000;
+					if (p * 100 / ((num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000) 
+						> (p - 1) * 100 / ((num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000))
+					{
+						device_print_progress(p, (num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000);
+					}
+				}
+				continue;
+			}
+
+			/******************************************************************************
+			shift ray position relative to center
+			******************************************************************************/
+			w -= center_y;
+
+			/******************************************************************************
+			if the ray landed outside the receiving region
+			******************************************************************************/
+			if (w.re < -hly.re || w.re > hly.re || w.im < -hly.im || w.im > hly.im)
+			{
+				if (threadIdx.x == 0 && threadIdx.y == 0)
+				{
+					int p = atomicAdd(percentage, 1) / 1000;
+					if (p * 100 / ((num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000) 
+						> (p - 1) * 100 / ((num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000))
+					{
+						device_print_progress(p, (num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000);
+					}
+				}
+				continue;
+			}
+
+			Complex<int> ypix = point_to_pixel<int, T>(w, hly, npixels);
+
+			/******************************************************************************
+			account for possible rounding issues when converting to integer pixels
+			******************************************************************************/
+			if (ypix.re == npixels.re)
+			{
+				ypix.re--;
+			}
+			if (ypix.im == npixels.im)
+			{
+				ypix.im--;
+			}
+
+			/******************************************************************************
+			reverse y coordinate so array forms image in correct orientation
+			******************************************************************************/
+			ypix.im = npixels.im - 1 - ypix.im;
+
+			if (pixmin && pixsad)
+			{
+				T mu = magnification<T>(z, kappa, gamma, theta, stars, kappastar, node, rectangular, corner, approx, taylor_smooth);
+				if (mu >= 0)
+				{
+					atomicAdd(&pixmin[ypix.im * npixels.re + ypix.re], 1);
+				}
+				else
+				{
+					atomicAdd(&pixsad[ypix.im * npixels.re + ypix.re], 1);
 				}
 			}
-			for (int i = threadIdx.x; i < node->num_neighbors; i += blockDim.x)
-			{
-				TreeNode<T>* neighbor = node->neighbors[i];
-				for (int j = threadIdx.y; j < neighbor->numstars; j += blockDim.y)
-				{
-					tmp_stars[atomicAdd(&nstars, 1)] = stars[neighbor->stars + j];
-				}
-			}
-			__syncthreads();
-
+			atomicAdd(&pixels[ypix.im * npixels.re + ypix.re], 1);
+			
 			if (threadIdx.x == 0 && threadIdx.y == 0)
 			{
-				node->num_neighbors = 0;
-				node->stars = 0;
-				node->numstars = nstars;
-			}
-			__syncthreads();
-
-			int num_rays = (2 << num_rays_factor);
-			Complex<T> ray_half_sep = block_half_length / num_rays;
-			Complex<int> ypix;
-			Complex<T> z;
-			Complex<T> w;
-			for (int j = threadIdx.y; j < num_rays; j += blockDim.y)
-			{
-				for (int i = threadIdx.x; i < num_rays; i += blockDim.x)
+				int p = atomicAdd(percentage, 1) / 1000;
+				if (p * 100 / ((num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000) 
+					> (p - 1) * 100 / ((num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000))
 				{
-					z = block_center - block_half_length + ray_half_sep + 2 * Complex<T>(ray_half_sep.re * i, ray_half_sep.im * j);
-					w = complex_image_to_source<T>(z, kappa, gamma, theta, tmp_stars, kappastar, node, rectangular, corner, approx, taylor_smooth);
-					
-					/******************************************************************************
-					if the ray location is the same as a star position, we will have a nan returned
-					******************************************************************************/
-					if (isnan(w.re) || isnan(w.im))
-					{
-						continue;
-					}
-
-					/******************************************************************************
-					shift ray position relative to center
-					******************************************************************************/
-					w -= center_y;
-
-					/******************************************************************************
-					if the ray landed outside the receiving region
-					******************************************************************************/
-					if (w.re < -hly.re || w.re > hly.re || w.im < -hly.im || w.im > hly.im)
-					{
-						continue;
-					}
-
-					ypix = point_to_pixel<int, T>(w, hly, npixels);
-
-					/******************************************************************************
-					account for possible rounding issues when converting to integer pixels
-					******************************************************************************/
-					if (ypix.re == npixels.re)
-					{
-						ypix.re--;
-					}
-					if (ypix.im == npixels.im)
-					{
-						ypix.im--;
-					}
-
-					/******************************************************************************
-					reverse y coordinate so array forms image in correct orientation
-					******************************************************************************/
-					ypix.im = npixels.im - 1 - ypix.im;
-
-					if (pixmin && pixsad)
-					{
-						T mu = magnification<T>(z, kappa, gamma, theta, tmp_stars, kappastar, node, rectangular, corner, approx, taylor_smooth);
-						if (mu >= 0)
-						{
-							atomicAdd(&pixmin[ypix.im * npixels.re + ypix.re], 1);
-						}
-						else
-						{
-							atomicAdd(&pixsad[ypix.im * npixels.re + ypix.re], 1);
-						}
-					}
-					atomicAdd(&pixels[ypix.im * npixels.re + ypix.re], 1);
-
-				}
-			}
-			__syncthreads();
-			if (threadIdx.x == 0 && threadIdx.y == 0)
-			{
-				int p = atomicAdd(percentage, 1);
-				if (p * 100 / (numrayblocks.re * numrayblocks.im) > (p - 1) * 100 / (numrayblocks.re * numrayblocks.im))
-				{
-					device_print_progress(p, numrayblocks.re * numrayblocks.im);
+					device_print_progress(p, (num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000);
 				}
 			}
 		}

--- a/irs/irs_functions.cuh
+++ b/irs/irs_functions.cuh
@@ -110,7 +110,7 @@ template <typename T>
 __global__ void shoot_rays_kernel(T kappa, T gamma, T theta, star<T>* stars, T kappastar, TreeNode<T>* root, 
 	int rectangular, Complex<T> corner, int approx, int taylor_smooth,
 	Complex<T> ray_half_sep, Complex<int> num_ray_threads, Complex<T> center_x, Complex<T> hlx, 
-	Complex<T> center_y, Complex<T> hly, int* pixmin, int* pixsad, int* pixels, Complex<int> npixels, int* percentage)
+	Complex<T> center_y, Complex<T> hly, int* pixmin, int* pixsad, int* pixels, Complex<int> npixels, unsigned long long int* percentage)
 {
 	for (int j = blockIdx.y * blockDim.y + threadIdx.y; j < num_ray_threads.im; j += blockDim.y * gridDim.y)
 	{
@@ -127,11 +127,13 @@ __global__ void shoot_rays_kernel(T kappa, T gamma, T theta, star<T>* stars, T k
 			{
 				if (threadIdx.x == 0 && threadIdx.y == 0)
 				{
-					int p = atomicAdd(percentage, 1) / 1000;
-					if (p * 100 / ((num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000) 
-						> (p - 1) * 100 / ((num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000))
+					unsigned long long int p = atomicAdd(percentage, 1);
+					unsigned long long int imax = num_ray_threads.re;
+					imax *= num_ray_threads.im;
+					imax /= (blockDim.x * blockDim.y);
+					if (p * 100 / imax > (p - 1) * 100 / imax)
 					{
-						device_print_progress(p, (num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000);
+						device_print_progress(p, imax);
 					}
 				}
 				continue;
@@ -149,11 +151,13 @@ __global__ void shoot_rays_kernel(T kappa, T gamma, T theta, star<T>* stars, T k
 			{
 				if (threadIdx.x == 0 && threadIdx.y == 0)
 				{
-					int p = atomicAdd(percentage, 1) / 1000;
-					if (p * 100 / ((num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000) 
-						> (p - 1) * 100 / ((num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000))
+					unsigned long long int p = atomicAdd(percentage, 1);
+					unsigned long long int imax = num_ray_threads.re;
+					imax *= num_ray_threads.im;
+					imax /= (blockDim.x * blockDim.y);
+					if (p * 100 / imax > (p - 1) * 100 / imax)
 					{
-						device_print_progress(p, (num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000);
+						device_print_progress(p, imax);
 					}
 				}
 				continue;
@@ -194,11 +198,13 @@ __global__ void shoot_rays_kernel(T kappa, T gamma, T theta, star<T>* stars, T k
 			
 			if (threadIdx.x == 0 && threadIdx.y == 0)
 			{
-				int p = atomicAdd(percentage, 1) / 1000;
-				if (p * 100 / ((num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000) 
-					> (p - 1) * 100 / ((num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000))
+				unsigned long long int p = atomicAdd(percentage, 1);
+				unsigned long long int imax = num_ray_threads.re;
+				imax *= num_ray_threads.im;
+				imax /= (blockDim.x * blockDim.y);
+				if (p * 100 / imax > (p - 1) * 100 / imax)
 				{
-					device_print_progress(p, (num_ray_threads.re / blockDim.x) * (num_ray_threads.im / blockDim.y) / 1000);
+					device_print_progress(p, imax);
 				}
 			}
 		}

--- a/irs/util.cuh
+++ b/irs/util.cuh
@@ -281,7 +281,7 @@ void show_device_info(int num, cudaDeviceProp& prop)
 	std::cout << "  Memory clock rate (kHz): " << prop.memoryClockRate << "\n";
 	std::cout << "  Memory bus width (bits): " << prop.memoryBusWidth << "\n";
 	std::cout << "  Peak memory bandwidth (GB/s): " << 2 * prop.memoryClockRate * (prop.memoryBusWidth / 8) / (1024 * 1024) << "\n";
-	std::cout << "  Single-to-double precision performance ratio: " << prop.singleToDoublePrecisionPerfRatio << "\n";
+	std::cout << "  Single to double precision performance ratio: " << prop.singleToDoublePrecisionPerfRatio << "\n";
 	std::cout << "  Total global memory (GB): " << prop.totalGlobalMem / (1024 * 1024 * 1024) << "\n";
 	std::cout << "  Shared memory per multiprocessor (kbytes): " << prop.sharedMemPerMultiprocessor / 1024 << "\n";
 	std::cout << "  Shared memory per block (kbytes): " << prop.sharedMemPerBlock / 1024 << "\n";

--- a/irs/util.cuh
+++ b/irs/util.cuh
@@ -120,7 +120,7 @@ examples: [====    ] 50%       [=====  ] 73%
 \param num_bars -- number of = symbols inside the bar
 				   default value: 50
 ******************************************************************************/
-void print_progress(int icurr, int imax, int num_bars = 50)
+void print_progress(unsigned long long int icurr, unsigned long long int imax, int num_bars = 50)
 {
 	std::cout << "\r[";
 	for (int i = 0; i < num_bars; i++)
@@ -136,9 +136,9 @@ void print_progress(int icurr, int imax, int num_bars = 50)
 	}
 	std::cout << "] " << icurr * 100 / imax << " %" << std::flush;
 }
-__device__ void device_print_progress(int icurr, int imax)
+__device__ void device_print_progress(unsigned long long int icurr, unsigned long long int imax)
 {
-	printf("\r%d %%", icurr * 100 / imax);
+	printf("\r%llu %%", icurr * 100 / imax);
 }
 
 /******************************************************************************


### PR DESCRIPTION
use arbitrary rectangular cells for shooting rays, rather than requiring they be distributed evenly in squares
update usage of threads and blocks to account for the fact that nodes don't need to be a multiple of the ray separation, as cells can cross across nodes and each corner of a cell needs to use its own appropriate node